### PR TITLE
Release 0.2.0 - create DNS record

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,3 +49,15 @@ resource "cloudflare_pages_domain" "ui" {
   domain       = "${var.subdomain}.${var.domain}"
   project_name = cloudflare_pages_project.ui.name
 }
+
+resource "cloudflare_record" "ui" {
+  zone_id = data.cloudflare_zone.domain.id
+  name    = var.subdomain
+  value   = cloudflare_pages_project.ui.subdomain
+  type    = "CNAME"
+  proxied = true
+}
+
+data "cloudflare_zone" "domain" {
+  name = var.domain
+}

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,6 @@ resource "cloudflare_pages_project" "ui" {
 
 resource "cloudflare_pages_domain" "ui" {
   account_id   = var.cloudflare_account_id
-  domain       = var.domain
+  domain       = "${var.subdomain}.${var.domain}"
   project_name = cloudflare_pages_project.ui.name
 }

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,6 @@ resource "cloudflare_pages_project" "ui" {
       environment_variables = {
         NODE_VERSION = "18"
       }
-      fail_open = true
     }
   }
 


### PR DESCRIPTION
### Fixed
- Removed `fail_open = true` to fix inconsistency.
- Use the fully-qualified domain name for the `domain` parameter.
- Create the DNS record. The `cloudflare_pages_domain` resources does not create it.